### PR TITLE
Axed the long-running subscriber thread.

### DIFF
--- a/rustkr/models/log.py
+++ b/rustkr/models/log.py
@@ -1,5 +1,6 @@
 
 import threading
+import time
 
 import settings
 
@@ -8,14 +9,14 @@ class Subscriber(threading.Thread):
         self.pubsub = redis.pubsub()
         self.pubsub.subscribe(settings.CHANNEL + 'out')
         self.result = None
+        self.keep_going = True
 
         threading.Thread.__init__(self)
         
     def run(self):
-        self.listener = self.pubsub.listen()
-        while True:
-            message = self.listener.next()
-            if message['type'] == 'subscribe':
-                continue
-            self.result = message['data']
-            break
+        while self.keep_going:
+            message = self.pubsub.get_message()
+            if message and message['type'] != 'subscribe':
+                self.result = message['data']
+                break
+            time.sleep(0.001)

--- a/rustkr/views/frontend.py
+++ b/rustkr/views/frontend.py
@@ -63,12 +63,11 @@ def update():
     if len(new) == 0:
         subscriber = Subscriber(client)
         subscriber.start()
-        for x in xrange(0, 300):
-            time.sleep(1)
-            if subscriber.result is not None:
-                print subscriber.result
-                new.append(parse_data(subscriber.result))
-                break
+        subscriber.join(10)
+        subscriber.keep_going = False # weed the thread out
+        if subscriber.result is not None:
+            print subscriber.result
+            new.append(parse_data(subscriber.result))
 
     return json.dumps(new)
 


### PR DESCRIPTION
* Shortened the timeout to 10 seconds.
* Made the subscriber running only before the timeout is reached; then it always cleans it up immediately.